### PR TITLE
Add pre-commit hooks that match current QA tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: local
+    hooks:
+      - id: black
+        name: Run black through poetry
+        entry: poetry run black annotile tests
+        language: system
+        types: [python]
+
+      - id: ruff
+        name: Run ruff through poetry
+        entry: poetry run ruff check annotile tests
+        language: system
+        types: [python]
+
+      - id: mypy
+        name: Run mypy through poetry
+        entry: poetry run mypy annotile tests
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      - id: pydoclint
+        name: Run pydoclint through poetry
+        entry: poetry run pydoclint
+        language: system
+        types: [python]


### PR DESCRIPTION
## Summary
This PR adds pre-commit hooks that track the current QA tools being used (black, mypy, ruff, etc) and ensures the output from both running using just commands and pre-commit hooks are identical. 

Closes #1 

## Changes
- Add pre-commit hooks that match current QA tools
